### PR TITLE
fix: update build command to set base href for deployment

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -30,7 +30,7 @@ jobs:
         run: npm install
 
       - name: Build
-        run: npm run build
+        run: npm run build -- --base-href /pixart/
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
This pull request makes a small change to the deployment workflow, updating the build command to set a custom base href for the deployed site. This ensures the application will work correctly when served from the `/pixart/` subdirectory.