### PR TITLE
feat: add transloco loader setup for GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -28,7 +28,10 @@ jobs:
 
       - name: Install dependencies
         run: npm install
-
+      - name: Set up transloco loader for GitHub Pages
+        run: |
+          rm src/app/i18n/transloco-loader.ts
+          mv src/app/i18n/transloco-loader.github-deployment.ts src/app/i18n/transloco-loader.ts
       - name: Build
         run: npm run build -- --base-href /pixart/
 

--- a/src/app/i18n/transloco-loader.github-deployment.ts
+++ b/src/app/i18n/transloco-loader.github-deployment.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@angular/core';
+import { TranslocoLoader } from '@jsverse/transloco';
+
+@Injectable({ providedIn: 'root' })
+export class TranslocoHttpLoader implements TranslocoLoader {
+  getTranslation(lang: string) {
+    return fetch(`/pixart/i18n/${lang}.json`).then((res) => res.json());
+  }
+}


### PR DESCRIPTION
This pull request updates the deployment workflow and internationalization (i18n) setup to ensure proper language file loading when deploying to GitHub Pages. The main changes involve configuring the correct i18n loader for the GitHub Pages environment.

**Deployment workflow updates:**

- Modified `.github/workflows/deploy-pages.yml` to replace `transloco-loader.ts` with a GitHub Pages-specific version (`transloco-loader.github-deployment.ts`) during deployment, ensuring the app loads translations from the correct path.

**Internationalization loader implementation:**

- Added a new `TranslocoHttpLoader` in `transloco-loader.github-deployment.ts` that fetches translation files from the `/pixart/i18n/` directory, which matches the GitHub Pages deployment structure.