### PR TITLE
Deployment workflow updates

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -28,7 +28,10 @@ jobs:
 
       - name: Install dependencies
         run: npm install
-
+      - name: Set up transloco loader for GitHub Pages
+        run: |
+          rm src/app/i18n/transloco-loader.ts
+          mv src/app/i18n/transloco-loader.github-deployment.ts src/app/i18n/transloco-loader.ts
       - name: Build
         run: npm run build -- --base-href /pixart/
 

--- a/src/app/i18n/transloco-loader.github-deployment.ts
+++ b/src/app/i18n/transloco-loader.github-deployment.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@angular/core';
+import { TranslocoLoader } from '@jsverse/transloco';
+
+@Injectable({ providedIn: 'root' })
+export class TranslocoHttpLoader implements TranslocoLoader {
+  getTranslation(lang: string) {
+    return fetch(`/pixart/i18n/${lang}.json`).then((res) => res.json());
+  }
+}


### PR DESCRIPTION
This pull request updates the deployment workflow and internationalization (i18n) loader to support serving the application from a subdirectory on GitHub Pages. The changes ensure that language files are loaded correctly when the app is deployed at `/pixart/`.

**Deployment workflow updates:**

- Modified the GitHub Actions deployment workflow to replace the default `transloco-loader.ts` with a GitHub Pages-specific version before building, and set the build's base href to `/pixart/` to ensure correct asset resolution.

**i18n loader update:**

- Added a new `TranslocoHttpLoader` in `transloco-loader.github-deployment.ts` that fetches translation files from the `/pixart/i18n/` directory, making the app's internationalization compatible with GitHub Pages subdirectory deployments.